### PR TITLE
Update 06620.json

### DIFF
--- a/stations/06620.json
+++ b/stations/06620.json
@@ -1,7 +1,7 @@
 {
     "id": "06620",
     "name": {
-        "en": "Schaffhausen \/ Neuhausem"
+        "en": "Schaffhausen \/ Neuhausen"
     },
     "country": "CH",
     "region": "SH",


### PR DESCRIPTION
Corrected spelling (not Neuhausem but Neuhausen)
Ref to Wikipedia: Neuhausen am Rheinfall is a town and a municipality in the canton of Schaffhausen in Switzerland. The town is close to the Rhine Falls, a tourist attraction and mainland Europe's largest waterfall. https://en.wikipedia.org/wiki/Neuhausen_am_Rheinfall