### PR TITLE
Fix JSON syntax of station 02409

### DIFF
--- a/stations/02409.json
+++ b/stations/02409.json
@@ -2,7 +2,7 @@
     "id": "02409",
     "name": {
         "en": "Amal Vänersvik",
-        "sv": "Åmål Vänersvik",
+        "sv": "Åmål Vänersvik"
     },
     "country": "SE",
     "region": "VG",


### PR DESCRIPTION
Dear Christian and Julia,

thanks a stack for creating and maintaining this repository of weather stations. As the file for Åmål Vänersvik (02409) had invalid JSON, this is a patch to fix it.

With kind regards,
Andreas.