### PR TITLE
Fix time zone for Unalaska Airport

### DIFF
--- a/stations/70489.json
+++ b/stations/70489.json
@@ -18,5 +18,5 @@
         "longitude": -166.5333,
         "elevation": 7
     },
-    "timezone": "America/Adak"
+    "timezone": "America/Anchorage"
 }


### PR DESCRIPTION
Unalaska isn't in the Hawaii-Aleutian time zone, it's in Alaska Standard Time. (UTC -9, -8 during DST)

Primary source - US federal code defines the Hawaii-Aleutian time zone to include parts of Alaska west of 169 degrees 30 minutes west longitude: https://www.ecfr.gov/current/title-49/subtitle-A/part-71/section-71.12

That's 3 degrees longitude west of this weather station. 

Seconary source, Geonames database: https://www.geonames.org/5877208/unalaska.html

Interestingly, someone had to fix this in GeoNames back in 2019 as well. Makes me think some upstream database has the time zone wrong for this town. I have a friend staying there right now and her phone was off by an hour, apparently Mac computers using geolocation for the time zone set themselves wrong there too.
